### PR TITLE
Fix 10 RNG/pool/effect divergences found by live differential validation

### DIFF
--- a/jackdaw/engine/card_factory.py
+++ b/jackdaw/engine/card_factory.py
@@ -361,6 +361,13 @@ def create_card(
     card = Card()
     card.set_ability(key)
 
+    # Card:set_ability registers EVERY created center key in
+    # G.GAME.used_jokers (card.lua:349-354) — shop displays, pack contents,
+    # and consumable-created cards alike.  This drives run-wide duplicate
+    # exclusion in all pools (a key never repeats without Showman).
+    if game_state is not None:
+        game_state.setdefault("used_jokers", {})[key] = True
+
     # ------------------------------------------------------------------
     # 3. Joker modifiers (shop / pack context only)
     # ------------------------------------------------------------------
@@ -533,7 +540,10 @@ def resolve_create_descriptor(
         rng,
         ante,
         area="",  # no shop/pack stickers for consumable-triggered creation
-        soulable=True,
+        # Vanilla passes soulable=nil for every consumable/joker-triggered
+        # create_card call (only pack opening passes soulable=true), so
+        # descriptor-created cards never roll the Soul/Black Hole chance.
+        soulable=False,
         forced_key=forced_key,
         forced_rarity=forced_rarity,
         append=append,

--- a/jackdaw/engine/game.py
+++ b/jackdaw/engine/game.py
@@ -349,12 +349,16 @@ def _apply_tag_result(gs: dict[str, Any], result: Any) -> None:
         for _ in range(result.create_jokers):
             if len(jokers) >= joker_slots:
                 break
+            # Top-up Tag: create_card('Joker', G.jokers, nil, 0, nil, nil,
+            # nil, 'top') — forced Common, append 'top' (tag.lua:138)
             card = create_card(
                 "Joker",
                 rng,
                 ante,
                 area="",
+                soulable=False,
                 forced_rarity=1,
+                append="top",
                 game_state=gs,
             )
             jokers.append(card)
@@ -788,16 +792,14 @@ def _handle_discard(gs: dict[str, Any], indices: tuple[int, ...]) -> dict[str, A
     jokers_to_remove: list = []
 
     for card in discarded:
-        # Seal: Purple Seal → create Tarot
+        # Seal: Purple Seal → create random Tarot with append '8ba'
+        # (card.lua:2254-2260; slot check gates the roll so no RNG is
+        # consumed when consumable slots are full)
         if getattr(card, "seal", None) == "Purple":
             consumables: list = gs.setdefault("consumables", [])
             consumable_limit = gs.get("consumable_slots", 2)
             if len(consumables) < consumable_limit:
-                from jackdaw.engine.card import Card as _Card
-
-                tarot = _Card(center_key="c_fool")
-                tarot.ability = {"set": "Tarot", "effect": ""}
-                consumables.append(tarot)
+                _resolve_create_descriptors(gs, [{"type": "Tarot", "count": 1, "seed": "8ba"}])
 
         # Fire joker discard context per card
         card_destroyed = False
@@ -934,6 +936,7 @@ def _build_discard_snapshot(gs: dict[str, Any], jokers: list) -> Any:
         discards_left=cr.get("discards_left", 0),
         discards_used=cr.get("discards_used", 0),
         mail_card_id=cr.get("mail_card", {}).get("id"),
+        castle_card_suit=cr.get("castle_card", {}).get("suit"),
         skips=gs.get("skips", 0),
     )
 
@@ -949,9 +952,18 @@ def _handle_cash_out(gs: dict[str, Any]) -> dict[str, Any]:
     """
     _require_phase(gs, GamePhase.ROUND_EVAL)
 
+    # End-of-round targeting-card re-roll (state_events.lua:273-276):
+    # idol / mail / ancient / castle streams advance once per round END
+    # (they are NOT re-rolled at round start; see start_round).
+    rng = gs.get("rng")
+    if rng:
+        from jackdaw.engine.round_lifecycle import reset_round_targets
+
+        ante = gs.get("round_resets", {}).get("ante", 1)
+        reset_round_targets(rng, ante, gs)
+
     # Shuffle deck at cash-out (button_callbacks.lua:2918)
     # G.deck:shuffle('cashout'..G.GAME.round_resets.ante)
-    rng = gs.get("rng")
     if rng:
         deck: list = gs.get("deck", [])
         ante = gs.get("round_resets", {}).get("ante", 1)
@@ -1087,6 +1099,7 @@ def _handle_use_consumable(
         consumables=consumables,
         joker_limit=gs.get("joker_slots", 5),
         consumable_limit=gs.get("consumable_slots", 2),
+        game_state=gs,
     ):
         consumable_name = card.ability.get("name", card.center_key)
         raise IllegalActionError(f"Consumable {consumable_name!r} cannot be used at this time")
@@ -1725,23 +1738,11 @@ def _apply_setting_blind_mutations(
                 if create.get("seal"):
                     c.seal = "Gold"  # Certificate default
                 deck.append(c)
-            elif ctype == "Joker":
-                # Riff-raff: create Common jokers
-                count = create.get("count", 1)
-                for _ in range(count):
-                    from jackdaw.engine.card import Card as _Card
-
-                    j = _Card(center_key="j_joker")
-                    j.ability = {"set": "Joker", "effect": "", "name": "Joker"}
-                    jokers.append(j)
-            elif ctype == "Tarot":
-                # Cartomancer: create Tarot
-                consumables: list = gs.setdefault("consumables", [])
-                from jackdaw.engine.card import Card as _Card2
-
-                t = _Card2(center_key="c_fool")
-                t.ability = {"set": "Tarot", "effect": ""}
-                consumables.append(t)
+            elif ctype in ("Joker", "Tarot", "Planet", "Spectral"):
+                # Riff-raff ('rif', Common), Cartomancer ('car'), 8 Ball
+                # ('8ba'), etc. — roll the real pool with the descriptor's
+                # append key instead of hardcoding a center.
+                _resolve_create_descriptors(gs, [create])
 
 
 # ---------------------------------------------------------------------------
@@ -1979,24 +1980,32 @@ def _apply_consumable_result(
     if getattr(result, "add_to_deck", None):
         import copy as _copy
 
-        from jackdaw.engine.card import Card as _Card
+        from jackdaw.engine.card import Card as _Card, _next_sort_id
 
         deck_list: list = gs.setdefault("deck", [])
         for card_spec in result.add_to_deck:
-            # Cryptid: copy an existing card
+            # Cryptid: copy an existing card — copies are emplaced into the
+            # HAND, not the draw pile (card.lua:1206-1213: copy_card +
+            # G.hand:emplace), with a fresh sort_id like any new Card.
             copy_source = card_spec.get("copy_of")
             if copy_source is not None:
                 new_card = _copy.deepcopy(copy_source)
-            else:
-                new_card = _Card()
-                if "suit" in card_spec and "rank" in card_spec:
-                    new_card.set_base(
-                        card_spec.get("key", ""),
-                        card_spec["suit"],
-                        card_spec["rank"],
-                    )
-                if "enhancement" in card_spec:
-                    new_card.set_ability(card_spec["enhancement"])
+                new_card.sort_id = _next_sort_id()
+                if gs.get("phase") == GamePhase.SELECTING_HAND:
+                    gs.setdefault("hand", []).append(new_card)
+                    _sort_hand_desc(gs.get("hand", []))
+                else:
+                    deck_list.append(new_card)
+                continue
+            new_card = _Card()
+            if "suit" in card_spec and "rank" in card_spec:
+                new_card.set_base(
+                    card_spec.get("key", ""),
+                    card_spec["suit"],
+                    card_spec["rank"],
+                )
+            if "enhancement" in card_spec:
+                new_card.set_ability(card_spec["enhancement"])
             deck_list.append(new_card)
 
     # ---- Joker effects ----
@@ -2037,6 +2046,9 @@ def _resolve_create_descriptors(gs: dict[str, Any], descriptors: list[dict[str, 
 
     rng = gs.get("rng")
     ante = gs.get("round_resets", {}).get("ante", 1)
+    # Planet pool softlock filtering needs current played-hand counts
+    # (High Priestess / Blue Seal create Planets mid-round).
+    _sync_played_hand_types(gs)
     consumables: list = gs.setdefault("consumables", [])
     consumable_limit = gs.get("consumable_slots", 2)
     jokers: list = gs.setdefault("jokers", [])
@@ -2079,23 +2091,23 @@ def _resolve_create_descriptors(gs: dict[str, Any], descriptors: list[dict[str, 
 
 
 def _sync_played_hand_types(gs: dict[str, Any]) -> None:
-    """Populate ``gs["played_hand_types"]`` from hand level visibility.
+    """Populate ``gs["played_hand_types"]`` from per-run play counts.
 
-    In Lua, ``G.GAME.hands[ht].visible`` gates whether a planet can
-    appear in pools (softlock).  Secret hand types (Five of a Kind,
-    Flush House, Flush Five) start invisible and become visible once
-    played or leveled.  This syncs that state so pool filtering works.
+    The Planet pool softlock gate is ``G.GAME.hands[hand_type].played > 0``
+    (common_events.lua:2009) — a hand type counts only once it has been
+    PLAYED this run.  Leveling a secret hand (e.g. via a Ceres from a pack)
+    makes it *visible* but does not unlock its planet in pools.
     """
     from jackdaw.engine.hand_levels import HandLevels
 
     hand_levels: HandLevels | None = gs.get("hand_levels")
     if hand_levels is None:
         return
-    visible: set[str] = set()
+    played: set[str] = set()
     for ht, state in hand_levels._hands.items():
-        if state.visible:
-            visible.add(ht.value)
-    gs["played_hand_types"] = visible
+        if state.played > 0:
+            played.add(ht.value)
+    gs["played_hand_types"] = played
 
 
 def _populate_shop(gs: dict[str, Any]) -> None:
@@ -2110,8 +2122,8 @@ def _populate_shop(gs: dict[str, Any]) -> None:
     if rng is None:
         return
 
-    # Sync visible hand types for Planet pool softlock filtering.
-    # In Lua, G.GAME.hands[ht].visible gates planet availability.
+    # Sync played hand types for Planet pool softlock filtering
+    # (G.GAME.hands[ht].played > 0, common_events.lua:2009).
     _sync_played_hand_types(gs)
 
     ante = gs.get("round_resets", {}).get("ante", 1)

--- a/jackdaw/engine/jokers.py
+++ b/jackdaw/engine/jokers.py
@@ -55,6 +55,7 @@ class GameSnapshot:
     mail_card_id: int | None = None
     idol_card: dict[str, Any] | None = None
     ancient_suit: str | None = None
+    castle_card_suit: str | None = None
     skips: int = 0
 
 
@@ -2420,7 +2421,11 @@ def _castle(card: Card, ctx: JokerContext) -> JokerResult | None:
     Fires in discard context.
     """
     if ctx.discard and ctx.other_card is not None and not ctx.blueprint:
-        castle_suit = card.ability.get("castle_card_suit")
+        # Suit lives on G.GAME.current_round.castle_card (card.lua:2857),
+        # not on the joker — read it from the game snapshot.
+        castle_suit = (ctx.game.castle_card_suit if ctx.game else None) or card.ability.get(
+            "castle_card_suit"
+        )
         if castle_suit and ctx.other_card.is_suit(castle_suit, smeared=ctx.smeared):
             extra = card.ability.get("extra", {})
             extra["chips"] = extra.get("chips", 0) + extra.get("chip_mod", 3)

--- a/jackdaw/engine/pools.py
+++ b/jackdaw/engine/pools.py
@@ -521,23 +521,22 @@ def _is_softlocked_planet(key: str, visible_hand_types: set[str]) -> bool:
     return hand_type not in visible_hand_types
 
 
+_SOFTLOCK_PLANETS: dict[str, str] = {
+    "c_planet_x": "Five of a Kind",
+    "c_ceres": "Flush House",
+    "c_eris": "Flush Five",
+}
+
+
 def _filter_planet(*, key: str, played_hand_types: set[str]) -> str:
-    """Exclude planet if its hand type has never been played (softlock guard).
+    """Exclude softlock planets until their hand type has been played this run.
 
-    The hand-type association is encoded in the planet key itself:
-    ``c_mercury`` → ``"High Card"``, etc.  We only apply the softlock filter
-    when ``played_hand_types`` is non-empty (caller opted in).
+    common_events.lua:2008-2011 gates only planets with ``config.softlock``
+    (Planet X / Ceres / Eris) on ``G.GAME.hands[hand_type].played > 0``.
+    All other planets are always eligible regardless of play history.
     """
-    if not played_hand_types:
-        return key
-
-    hand_type = _PLANET_HAND.get(key)
-    if hand_type is None:
-        # Unknown planet key — allow through
-        return key
-    if hand_type == "all":
-        return key
-    if hand_type not in played_hand_types:
+    hand_type = _SOFTLOCK_PLANETS.get(key)
+    if hand_type is not None and hand_type not in played_hand_types:
         return UNAVAILABLE
     return key
 

--- a/jackdaw/engine/round_lifecycle.py
+++ b/jackdaw/engine/round_lifecycle.py
@@ -204,10 +204,17 @@ def reset_round_targets(
         and ``deck`` list of Card objects.
     """
     cr = game_state["current_round"]
-    deck: list[Card] = game_state.get("deck", [])
+    # Vanilla iterates G.playing_cards — every playing card in the run
+    # regardless of zone (deck / hand / discard).  rng.element re-sorts by
+    # sort_id, so zone concatenation order is irrelevant.
+    all_cards: list[Card] = [
+        *game_state.get("deck", []),
+        *game_state.get("hand", []),
+        *game_state.get("discard_pile", []),
+    ]
 
     # Filter out Stone cards — only non-Stone playing cards are eligible
-    valid_cards = [c for c in deck if _card_effect(c) != "Stone Card"]
+    valid_cards = [c for c in all_cards if _card_effect(c) != "Stone Card"]
 
     # ------------------------------------------------------------------
     # reset_idol_card — common_events.lua:2271-2286

--- a/jackdaw/engine/run_init.py
+++ b/jackdaw/engine/run_init.py
@@ -416,12 +416,11 @@ def start_round(game_state: dict[str, Any]) -> None:
     if hand_levels is not None:
         hand_levels.reset_round_counts()
 
-    # Reset targeting cards (idol, mail, ancient, castle) — state_events.lua:273-276
-    # These are re-rolled every round from the current deck state.
-    rng = game_state.get("rng")
-    ante = rr.get("ante", 1)
-    if rng is not None:
-        reset_round_targets(rng, ante, game_state)
+    # NOTE: targeting cards (idol, mail, ancient, castle) are NOT re-rolled
+    # here.  Vanilla rolls them once at run start (game.lua:2385-2389) and
+    # then at each round END (state_events.lua:273-276) — never at round
+    # start.  Rolling here would double-advance the 'idol/mail/anc/cas'
+    # streams.  See _handle_cash_out in game.py for the round-end roll.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/cross_validation/shop.json
+++ b/tests/fixtures/cross_validation/shop.json
@@ -106,7 +106,7 @@
           "set": "Planet"
         },
         {
-          "key": "c_uranus",
+          "key": "c_neptune",
           "cost": 3,
           "set": "Planet"
         }
@@ -143,7 +143,7 @@
           "set": "Tarot"
         },
         {
-          "key": "c_eris",
+          "key": "c_uranus",
           "cost": 3,
           "set": "Planet"
         }
@@ -156,7 +156,7 @@
       "voucher": "v_hieroglyph",
       "jokers": [
         {
-          "key": "c_ceres",
+          "key": "c_pluto",
           "cost": 3,
           "set": "Planet"
         },

--- a/tests/fixtures/shop_oracle_TESTSEED.json
+++ b/tests/fixtures/shop_oracle_TESTSEED.json
@@ -42,7 +42,7 @@
           "rental": true
         },
         {
-          "center_key": "c_ceres",
+          "center_key": "c_saturn",
           "set": "Planet"
         }
       ],
@@ -68,7 +68,7 @@
           "set": "Tarot"
         },
         {
-          "center_key": "c_eris",
+          "center_key": "c_uranus",
           "set": "Planet"
         }
       ],


### PR DESCRIPTION
## Context

I installed BalatroBot into a real copy of Balatro and ran this repo's live differential-validation scenarios end to end (fully-unlocked profile, smods pinned to `1.0.0-beta-1221a` since newer Steamodded's Galdur run-select page breaks balatrobot's start endpoint). Result before fixes: **266/275**. After the fixes in this PR: **270/275** — bosses 28/28, jokers 150/150, modifiers 22/22, planets 13/13, tarots 22/22 all perfect.

The remaining 5: 3 are smods harness artifacts (familiar/grim/incantation — Steamodded `take_ownership()`s those spectrals and rewrites their creation RNG, see #3 for scenario annotations), and 2 (`tag_buffoon`, `tag_top_up` on the FIND_6 multi-ante path) share one still-unresolved used_jokers/pool divergence I haven't pinpointed yet.

## Fixes (all verified against live-game probes + the extracted game source)

1. **Planet softlock filter** (`pools.py`): only softlock planets (Planet X / Ceres / Eris) gate on their hand having been **played** (`common_events.lua:2008-2011`, `G.GAME.hands[ht].played > 0`). The previous visible-based filter let High Priestess create Ceres and could over-filter regular planets. `_sync_played_hand_types` now syncs play counts, not visibility.
2. **`used_jokers` at creation time** (`card_factory.py`): `Card:set_ability` registers *every* created center key in `G.GAME.used_jokers` (`card.lua:349-354`) — shop displays, pack contents, and created consumables alike — driving run-wide duplicate exclusion. Buy-time-only tracking allowed impossible duplicates (one pinned fixture literally contained `c_uranus` twice in a single shop; live game shows `c_uranus, c_neptune`).
3. **Purple Seal** (`game.py`): rolls the Tarot pool with append `'8ba'` (`card.lua:2260` — genuinely the same key 8 Ball uses) instead of a hardcoded `c_fool`.
4. **Riff-raff / Cartomancer / 8 Ball** (`game.py`): creates route through the real pool resolver with `'rif'`/`'car'`/`'8ba'` appends instead of hardcoded `j_joker`/`c_fool`.
5. **Top-up Tag** (`game.py`): joker creation uses append `'top'` and forced Common (`tag.lua:138`).
6. **Targeting cards** (`run_init.py`, `round_lifecycle.py`, `game.py`): Idol/Mail/Ancient/Castle roll at run start + round **END** (`state_events.lua:273-276`), not round start — the sim was one stream advance ahead, so all four targets were wrong from round 1. Rolls now cover all playing cards (deck+hand+discard), matching `G.playing_cards`.
7. **Castle suit** (`jokers.py`): read from `current_round.castle_card` via the game snapshot (`card.lua:2857`); the joker-ability field it previously read was never written.
8. **Cryptid** (`game.py`): copies emplace into the **hand** with fresh `sort_id`s (`card.lua:1206-1213`), not the draw pile.
9. **The Fool** (`game.py`): the can-use gate now receives `game_state`, so `last_tarot_planet` is actually visible and the card is usable.
10. **`soulable`** (`card_factory.py`): descriptor-created cards pass `soulable=False` — vanilla only soul-rolls pack-opened cards, so consumable/joker-triggered creates must not consume `soul_*` streams.

## Fixture corrections

The shop-oracle fixtures were generated by the sim itself, so they had pinned bugs 1–2. The corrected values in `tests/fixtures/cross_validation/shop.json` and `tests/fixtures/shop_oracle_TESTSEED.json` were live-verified via BalatroBot probes (TESTSEED ante 3, TUTORIAL ante 1, SHOP_B ante 3, SHOP_C antes 2+3).

## Testing

- Offline suite: **1480 passed** (including the LuaJIT cross-validation tests).
- Live re-run of the full scenario set: 270/275 as above.

Happy to split this up if you'd prefer smaller PRs — the pieces that must stay together are 1 + 2 + the fixture corrections (the corrected shop contents reflect both fixes combined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

