### PR TITLE
Fix PROJECT_ROOT in run_shop_oracle.py

### DIFF
--- a/scripts/generate_fixtures/run_shop_oracle.py
+++ b/scripts/generate_fixtures/run_shop_oracle.py
@@ -21,7 +21,7 @@ import json
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from jackdaw.engine.rng import PseudoRandom  # noqa: E402


### PR DESCRIPTION
`Path(__file__).resolve().parent.parent` resolves to `scripts/` for a file located at `scripts/generate_fixtures/run_shop_oracle.py`, so the `sys.path.insert` never made `import jackdaw` work when running the generator standalone. `parents[2]` reaches the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
