### PR TITLE
Handle nan-collapse 'bugged seeds' in pseudohash (Lua float semantics)

### DIFF
--- a/jackdaw/engine/rng.py
+++ b/jackdaw/engine/rng.py
@@ -234,7 +234,15 @@ def pseudohash(s: str) -> float:
     num = 1.0
     for i in range(len(s), 0, -1):
         byte = ord(s[i - 1])
-        num = ((1.1239285023 / num) * byte * math.pi + math.pi * i) % 1
+        # Lua float semantics: x/0 = inf, and inf/nan propagate through
+        # `% 1` as nan instead of raising. Certain "bugged" seeds (e.g.
+        # erratic 7LB2WVPK) hit num == 0 mid-hash and depend on the nan
+        # collapse pinning the downstream PRNG to a constant.
+        try:
+            q = 1.1239285023 / num
+        except ZeroDivisionError:
+            q = math.copysign(math.inf, num)
+        num = (q * byte * math.pi + math.pi * i) % 1
     return num
 
 

--- a/tests/engine/test_rng.py
+++ b/tests/engine/test_rng.py
@@ -697,3 +697,42 @@ class TestFullPipelineOracle:
             assert val == entry["value"], (
                 f"element trial {entry['trial']}: val {val} != {entry['value']}"
             )
+
+
+# ============================================================================
+# Bugged seeds — nan collapse (e.g. erratic 7LB2WVPK)
+# ============================================================================
+
+
+class TestBuggedSeedNanCollapse:
+    """Seeds whose pseudohash hits num == 0 mid-loop must collapse to nan.
+
+    Lua semantics: 1.x/0 = inf, then inf % 1 = nan, and the nan survives the
+    %.13f string round-trip (LuaJIT tonumber("nan") = nan). math.randomseed(nan)
+    deterministically pins the TW223 stream, which is why community "bugged
+    seeds" like erratic 7LB2WVPK deal 52 identical cards. Ground truth from
+    LuaJIT 2.1: randomseed(nan) -> random(1, 52) == 52 on every draw, and the
+    second float draw is 0.44933739017092433.
+    """
+
+    def test_pseudohash_nan(self):
+        import math
+
+        assert math.isnan(pseudohash("erratic7LB2WVPK"))
+
+    def test_nan_stream_is_pinned(self):
+        prng = PseudoRandom("7LB2WVPK")
+        assert prng.random("erratic", 1, 52) == 52
+        assert prng.random("erratic", 1, 52) == 52
+        a = prng.random("erratic")
+        b = prng.random("erratic")
+        assert a == b  # stream is pinned: every reseed yields the same draw
+        assert a >= 51 / 52  # consistent with random(1, 52) == 52
+
+    def test_erratic_freak_deck(self):
+        from jackdaw.engine.run_init import initialize_run
+
+        gs = initialize_run("b_erratic", 1, "7LB2WVPK")
+        identities = {(c.base.suit, c.base.rank) for c in gs["deck"]}
+        assert len(gs["deck"]) == 52
+        assert len(identities) == 1  # the famous all-one-card deck


### PR DESCRIPTION
## Summary

`pseudohash` raises `ZeroDivisionError` on the community's famous "bugged seeds" (e.g. the all-10-of-Spades Erratic seed `7LB2WVPK`), crashing any code that touches one. In Lua the same input produces `inf` then `nan`, and the nan deterministically pins `math.randomseed` — that collapse IS the famous freak-deck behavior.

## The mechanism (verified against LuaJIT 2.1)

Certain key+seed strings drive `num` to exactly `0` mid-hash. Lua then computes `1.1239285023/0 = inf`, `inf % 1 = nan`, and the nan survives the `tonumber(string.format("%.13f", ...))` round-trip because LuaJIT parses `"nan"` back to a canonical qNaN. `math.randomseed(nan)` then produces a constant stream: `random(1, 52)` returns 52 on every draw (ground truth from a direct LuaJIT probe), which is why `7LB2WVPK` deals 52 copies of the pool's last card.

## Fix

Emulate Lua float semantics exactly: division by zero yields signed `inf`; the nan propagates through the hash loop; and the existing `%.13f` round-trip canonicalizes it to the same `0x7ff8...` bit pattern LuaJIT feeds `randomseed`, so the TW223 port reproduces LuaJIT draw-for-draw with no further changes.

## Tests

Three regression tests: `pseudohash` nan collapse, pinned-stream draws (`random(1,52) == 52`, repeated float draws identical), and the full Erratic freak deck (52 identical cards via `initialize_run`). Full suite passes (1,483).

This matters beyond novelty seeds: any large-scale seed scan will eventually hit a nan-collapse seed and crash without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oGfm3wSmd1YoYmERrugsi
