### PR TITLE
Certificate/Marble front rolls + skip-tag hook wiring + pack joker-cap gate (stacks on #2)

### DIFF
--- a/jackdaw/engine/actions.py
+++ b/jackdaw/engine/actions.py
@@ -487,7 +487,19 @@ def _legal_pack_opening(gs: dict[str, Any]) -> list[Action]:
     # via RPC, so only SkipPack is offered.  RNG stays in sync because
     # the pack is generated normally — we just force the agent to skip.
     if remaining > 0 and pack_type != "Spectral":
-        for i in range(len(pack_cards)):
+        # Vanilla gate (button_callbacks.lua:2112-2113): a Joker in a pack
+        # is selectable only if joker slots have room or it is negative.
+        jokers: list[Card] = gs.get("jokers", [])
+        joker_limit: int = gs.get("joker_slots", 5)
+        board_full = len(jokers) >= joker_limit
+        for i, card in enumerate(pack_cards):
+            if board_full:
+                ability = getattr(card, "ability", None) or {}
+                edition = getattr(card, "edition", None) or {}
+                is_joker = ability.get("set", "") == "Joker"
+                negative = bool(edition.get("negative")) if isinstance(edition, dict) else False
+                if is_joker and not negative:
+                    continue
             actions.append(PickPackCard(card_index=i))
 
     actions.append(SkipPack())

--- a/jackdaw/engine/card_factory.py
+++ b/jackdaw/engine/card_factory.py
@@ -361,6 +361,13 @@ def create_card(
     card = Card()
     card.set_ability(key)
 
+    # Card:set_ability registers EVERY created center key in
+    # G.GAME.used_jokers (card.lua:349-354) — shop displays, pack contents,
+    # and consumable-created cards alike.  This drives run-wide duplicate
+    # exclusion in all pools (a key never repeats without Showman).
+    if game_state is not None:
+        game_state.setdefault("used_jokers", {})[key] = True
+
     # ------------------------------------------------------------------
     # 3. Joker modifiers (shop / pack context only)
     # ------------------------------------------------------------------
@@ -533,7 +540,10 @@ def resolve_create_descriptor(
         rng,
         ante,
         area="",  # no shop/pack stickers for consumable-triggered creation
-        soulable=True,
+        # Vanilla passes soulable=nil for every consumable/joker-triggered
+        # create_card call (only pack opening passes soulable=true), so
+        # descriptor-created cards never roll the Soul/Black Hole chance.
+        soulable=False,
         forced_key=forced_key,
         forced_rarity=forced_rarity,
         append=append,

--- a/jackdaw/engine/game.py
+++ b/jackdaw/engine/game.py
@@ -349,12 +349,16 @@ def _apply_tag_result(gs: dict[str, Any], result: Any) -> None:
         for _ in range(result.create_jokers):
             if len(jokers) >= joker_slots:
                 break
+            # Top-up Tag: create_card('Joker', G.jokers, nil, 0, nil, nil,
+            # nil, 'top') — forced Common, append 'top' (tag.lua:138)
             card = create_card(
                 "Joker",
                 rng,
                 ante,
                 area="",
+                soulable=False,
                 forced_rarity=1,
+                append="top",
                 game_state=gs,
             )
             jokers.append(card)
@@ -788,16 +792,14 @@ def _handle_discard(gs: dict[str, Any], indices: tuple[int, ...]) -> dict[str, A
     jokers_to_remove: list = []
 
     for card in discarded:
-        # Seal: Purple Seal → create Tarot
+        # Seal: Purple Seal → create random Tarot with append '8ba'
+        # (card.lua:2254-2260; slot check gates the roll so no RNG is
+        # consumed when consumable slots are full)
         if getattr(card, "seal", None) == "Purple":
             consumables: list = gs.setdefault("consumables", [])
             consumable_limit = gs.get("consumable_slots", 2)
             if len(consumables) < consumable_limit:
-                from jackdaw.engine.card import Card as _Card
-
-                tarot = _Card(center_key="c_fool")
-                tarot.ability = {"set": "Tarot", "effect": ""}
-                consumables.append(tarot)
+                _resolve_create_descriptors(gs, [{"type": "Tarot", "count": 1, "seed": "8ba"}])
 
         # Fire joker discard context per card
         card_destroyed = False
@@ -934,6 +936,7 @@ def _build_discard_snapshot(gs: dict[str, Any], jokers: list) -> Any:
         discards_left=cr.get("discards_left", 0),
         discards_used=cr.get("discards_used", 0),
         mail_card_id=cr.get("mail_card", {}).get("id"),
+        castle_card_suit=cr.get("castle_card", {}).get("suit"),
         skips=gs.get("skips", 0),
     )
 
@@ -949,9 +952,18 @@ def _handle_cash_out(gs: dict[str, Any]) -> dict[str, Any]:
     """
     _require_phase(gs, GamePhase.ROUND_EVAL)
 
+    # End-of-round targeting-card re-roll (state_events.lua:273-276):
+    # idol / mail / ancient / castle streams advance once per round END
+    # (they are NOT re-rolled at round start; see start_round).
+    rng = gs.get("rng")
+    if rng:
+        from jackdaw.engine.round_lifecycle import reset_round_targets
+
+        ante = gs.get("round_resets", {}).get("ante", 1)
+        reset_round_targets(rng, ante, gs)
+
     # Shuffle deck at cash-out (button_callbacks.lua:2918)
     # G.deck:shuffle('cashout'..G.GAME.round_resets.ante)
-    rng = gs.get("rng")
     if rng:
         deck: list = gs.get("deck", [])
         ante = gs.get("round_resets", {}).get("ante", 1)
@@ -1087,6 +1099,7 @@ def _handle_use_consumable(
         consumables=consumables,
         joker_limit=gs.get("joker_slots", 5),
         consumable_limit=gs.get("consumable_slots", 2),
+        game_state=gs,
     ):
         consumable_name = card.ability.get("name", card.center_key)
         raise IllegalActionError(f"Consumable {consumable_name!r} cannot be used at this time")
@@ -1725,23 +1738,11 @@ def _apply_setting_blind_mutations(
                 if create.get("seal"):
                     c.seal = "Gold"  # Certificate default
                 deck.append(c)
-            elif ctype == "Joker":
-                # Riff-raff: create Common jokers
-                count = create.get("count", 1)
-                for _ in range(count):
-                    from jackdaw.engine.card import Card as _Card
-
-                    j = _Card(center_key="j_joker")
-                    j.ability = {"set": "Joker", "effect": "", "name": "Joker"}
-                    jokers.append(j)
-            elif ctype == "Tarot":
-                # Cartomancer: create Tarot
-                consumables: list = gs.setdefault("consumables", [])
-                from jackdaw.engine.card import Card as _Card2
-
-                t = _Card2(center_key="c_fool")
-                t.ability = {"set": "Tarot", "effect": ""}
-                consumables.append(t)
+            elif ctype in ("Joker", "Tarot", "Planet", "Spectral"):
+                # Riff-raff ('rif', Common), Cartomancer ('car'), 8 Ball
+                # ('8ba'), etc. — roll the real pool with the descriptor's
+                # append key instead of hardcoding a center.
+                _resolve_create_descriptors(gs, [create])
 
 
 # ---------------------------------------------------------------------------
@@ -1979,24 +1980,32 @@ def _apply_consumable_result(
     if getattr(result, "add_to_deck", None):
         import copy as _copy
 
-        from jackdaw.engine.card import Card as _Card
+        from jackdaw.engine.card import Card as _Card, _next_sort_id
 
         deck_list: list = gs.setdefault("deck", [])
         for card_spec in result.add_to_deck:
-            # Cryptid: copy an existing card
+            # Cryptid: copy an existing card — copies are emplaced into the
+            # HAND, not the draw pile (card.lua:1206-1213: copy_card +
+            # G.hand:emplace), with a fresh sort_id like any new Card.
             copy_source = card_spec.get("copy_of")
             if copy_source is not None:
                 new_card = _copy.deepcopy(copy_source)
-            else:
-                new_card = _Card()
-                if "suit" in card_spec and "rank" in card_spec:
-                    new_card.set_base(
-                        card_spec.get("key", ""),
-                        card_spec["suit"],
-                        card_spec["rank"],
-                    )
-                if "enhancement" in card_spec:
-                    new_card.set_ability(card_spec["enhancement"])
+                new_card.sort_id = _next_sort_id()
+                if gs.get("phase") == GamePhase.SELECTING_HAND:
+                    gs.setdefault("hand", []).append(new_card)
+                    _sort_hand_desc(gs.get("hand", []))
+                else:
+                    deck_list.append(new_card)
+                continue
+            new_card = _Card()
+            if "suit" in card_spec and "rank" in card_spec:
+                new_card.set_base(
+                    card_spec.get("key", ""),
+                    card_spec["suit"],
+                    card_spec["rank"],
+                )
+            if "enhancement" in card_spec:
+                new_card.set_ability(card_spec["enhancement"])
             deck_list.append(new_card)
 
     # ---- Joker effects ----
@@ -2037,6 +2046,9 @@ def _resolve_create_descriptors(gs: dict[str, Any], descriptors: list[dict[str, 
 
     rng = gs.get("rng")
     ante = gs.get("round_resets", {}).get("ante", 1)
+    # Planet pool softlock filtering needs current played-hand counts
+    # (High Priestess / Blue Seal create Planets mid-round).
+    _sync_played_hand_types(gs)
     consumables: list = gs.setdefault("consumables", [])
     consumable_limit = gs.get("consumable_slots", 2)
     jokers: list = gs.setdefault("jokers", [])
@@ -2079,23 +2091,23 @@ def _resolve_create_descriptors(gs: dict[str, Any], descriptors: list[dict[str, 
 
 
 def _sync_played_hand_types(gs: dict[str, Any]) -> None:
-    """Populate ``gs["played_hand_types"]`` from hand level visibility.
+    """Populate ``gs["played_hand_types"]`` from per-run play counts.
 
-    In Lua, ``G.GAME.hands[ht].visible`` gates whether a planet can
-    appear in pools (softlock).  Secret hand types (Five of a Kind,
-    Flush House, Flush Five) start invisible and become visible once
-    played or leveled.  This syncs that state so pool filtering works.
+    The Planet pool softlock gate is ``G.GAME.hands[hand_type].played > 0``
+    (common_events.lua:2009) — a hand type counts only once it has been
+    PLAYED this run.  Leveling a secret hand (e.g. via a Ceres from a pack)
+    makes it *visible* but does not unlock its planet in pools.
     """
     from jackdaw.engine.hand_levels import HandLevels
 
     hand_levels: HandLevels | None = gs.get("hand_levels")
     if hand_levels is None:
         return
-    visible: set[str] = set()
+    played: set[str] = set()
     for ht, state in hand_levels._hands.items():
-        if state.visible:
-            visible.add(ht.value)
-    gs["played_hand_types"] = visible
+        if state.played > 0:
+            played.add(ht.value)
+    gs["played_hand_types"] = played
 
 
 def _populate_shop(gs: dict[str, Any]) -> None:
@@ -2110,8 +2122,8 @@ def _populate_shop(gs: dict[str, Any]) -> None:
     if rng is None:
         return
 
-    # Sync visible hand types for Planet pool softlock filtering.
-    # In Lua, G.GAME.hands[ht].visible gates planet availability.
+    # Sync played hand types for Planet pool softlock filtering
+    # (G.GAME.hands[ht].played > 0, common_events.lua:2009).
     _sync_played_hand_types(gs)
 
     ante = gs.get("round_resets", {}).get("ante", 1)

--- a/jackdaw/engine/game.py
+++ b/jackdaw/engine/game.py
@@ -1727,17 +1727,51 @@ def _apply_setting_blind_mutations(
             create = mut["create"]
             ctype = create.get("type", "")
             if ctype == "playing_card":
-                # Marble Joker: add Stone Card; Certificate: add card with seal
-                deck: list = gs.setdefault("deck", [])
-                from jackdaw.engine.card import Card
+                # Marble Joker (card.lua:2580): front via 'marb_fr', Stone
+                # center, joins the playing cards. Certificate (card.lua:2462):
+                # front via 'cert_fr' emplaced into the HAND, seal via
+                # 'certsl' (>0.75 Red, >0.5 Blue, >0.25 Gold, else Purple).
+                # The old code appended a Card with NO front (base=None),
+                # which corrupted the playing-card pool and crashed the
+                # round-end targeting rolls (mail.base.id).
+                from jackdaw.engine.card_factory import (
+                    RANK_LETTER,
+                    SUIT_LETTER,
+                    create_playing_card,
+                )
 
-                c = Card()
-                enhancement = create.get("enhancement")
-                if enhancement:
-                    c.ability = {"effect": enhancement, "set": "Enhanced"}
-                if create.get("seal"):
-                    c.seal = "Gold"  # Certificate default
-                deck.append(c)
+                ckey = create.get("key", "")
+                stream = {"cert": "cert_fr", "marble": "marb_fr"}.get(ckey)
+                if rng is not None and stream is not None:
+                    p_cards = {
+                        f"{sl}_{rl}": (suit, rank)
+                        for sl, suit in SUIT_LETTER.items()
+                        for rl, rank in RANK_LETTER.items()
+                    }
+                    (c_suit, c_rank), _ = rng.element(p_cards, rng.seed(stream))
+                    seal = None
+                    if create.get("seal"):
+                        roll = rng.random(rng.seed("certsl"))
+                        if roll > 0.75:
+                            seal = "Red"
+                        elif roll > 0.5:
+                            seal = "Blue"
+                        elif roll > 0.25:
+                            seal = "Gold"
+                        else:
+                            seal = "Purple"
+                    c = create_playing_card(
+                        c_suit,
+                        c_rank,
+                        create.get("enhancement", "c_base"),
+                        seal=seal,
+                        hands_played=gs.get("hands_played", 0),
+                    )
+                    if ckey == "cert" and gs.get("phase") == GamePhase.SELECTING_HAND:
+                        gs.setdefault("hand", []).append(c)
+                        _sort_hand_desc(gs.get("hand", []))
+                    else:
+                        gs.setdefault("deck", []).append(c)
             elif ctype in ("Joker", "Tarot", "Planet", "Spectral"):
                 # Riff-raff ('rif', Common), Cartomancer ('car'), 8 Ball
                 # ('8ba'), etc. — roll the real pool with the descriptor's

--- a/jackdaw/engine/game.py
+++ b/jackdaw/engine/game.py
@@ -974,6 +974,20 @@ def _handle_cash_out(gs: dict[str, Any]) -> dict[str, Any]:
     if earnings:
         gs["dollars"] = gs.get("dollars", 0) + earnings.total
 
+    # eval-context tags (Investment: $25 once per tag, after a boss kill).
+    if gs.get("last_blind_was_boss"):
+        from jackdaw.engine.tags import Tag
+
+        for entry in gs.get("awarded_tags", []):
+            if entry.get("eval_fired"):
+                continue
+            result = Tag(entry.get("key", "")).apply(
+                "eval", gs, rng=rng, last_blind_is_boss=True
+            )
+            if result is not None and result.dollars:
+                gs["dollars"] = gs.get("dollars", 0) + result.dollars
+                entry["eval_fired"] = True
+
     gs["previous_round"] = {"dollars": gs.get("dollars", 0)}
 
     # Populate shop
@@ -1587,6 +1601,8 @@ def _round_won(gs: dict[str, Any]) -> None:
     blind_on_deck = gs.get("blind_on_deck", "Small")
     rr["blind_states"][blind_on_deck] = "Defeated"
     gs["round"] = gs.get("round", 0) + 1
+    # Remembered for cash-out tag hooks (Investment Tag pays after a boss).
+    gs["last_blind_was_boss"] = blind_on_deck == "Boss"
 
     # ------------------------------------------------------------------
     # 8-9. Advance blind progression
@@ -2168,6 +2184,73 @@ def _populate_shop(gs: dict[str, Any]) -> None:
     gs["shop_vouchers"] = [voucher] if voucher else []
     gs["shop_boosters"] = result.get("boosters", [])
 
+    _fire_shop_tags(gs, rerolled=False)
+
+
+def _fire_shop_tags(gs: dict[str, Any], rerolled: bool) -> None:
+    """Fire pending shop-context tag hooks on freshly stocked shop cards.
+
+    Wires the hooks :func:`~jackdaw.engine.shop.populate_shop` defers (its
+    "M11 tag system" note), consuming awarded tags FIFO:
+
+    * ``store_joker_modify`` — Foil/Holo/Polychrome/Negative Tag: the next
+      base-edition shop Joker gains the edition and becomes free
+      (tags.lua ``Tag:apply_to_run``). Applies to rerolled jokers too.
+    * ``shop_final_pass`` — Coupon Tag: initial shop cards and boosters
+      become free (shop entry only).
+    * ``shop_start`` — D6 Tag: rerolls start free (shop entry only).
+
+    ``store_joker_create`` (Rare/Uncommon Tag) and ``voucher_add``
+    (Voucher Tag) remain unwired: both replace RNG-consuming rolls at
+    creation time, so a faithful implementation needs live validation to
+    pin stream behavior first. Those tags stay pending and inert rather
+    than risking a new stream divergence.
+    """
+    from jackdaw.engine.tags import Tag
+
+    awarded: list[dict[str, Any]] = gs.get("awarded_tags", [])
+    rng = gs.get("rng")
+
+    for entry in awarded:
+        if entry.get("shop_fired"):
+            continue
+        tag = Tag(entry.get("key", ""))
+
+        result = tag.apply("store_joker_modify", gs, rng=rng)
+        if result is not None and result.force_edition:
+            target = None
+            for c in gs.get("shop_cards", []):
+                ability = getattr(c, "ability", None) or {}
+                if ability.get("set") == "Joker" and not getattr(c, "edition", None):
+                    target = c
+                    break
+            if target is None:
+                continue  # no eligible joker; tag stays pending for later
+            edition = {str(result.force_edition): True}
+            if hasattr(target, "set_edition"):
+                target.set_edition(edition)
+            else:
+                target.edition = edition
+            target.cost = 0  # vanilla: tag-edition shop jokers are free
+            entry["shop_fired"] = True
+            continue
+
+        if rerolled:
+            continue  # remaining hooks fire on shop entry only
+
+        result = tag.apply("shop_final_pass", gs, rng=rng)
+        if result is not None and result.coupon:
+            for c in gs.get("shop_cards", []) + gs.get("shop_boosters", []):
+                c.cost = 0
+            entry["shop_fired"] = True
+            continue
+
+        result = tag.apply("shop_start", gs, rng=rng)
+        if result is not None and result.free_rerolls:
+            cr = gs.setdefault("current_round", {})
+            cr["free_rerolls"] = cr.get("free_rerolls", 0) + result.free_rerolls
+            entry["shop_fired"] = True
+
 
 def _reroll_shop_cards(gs: dict[str, Any]) -> None:
     """Regenerate the shop joker/consumable cards (not voucher or boosters).
@@ -2209,6 +2292,8 @@ def _reroll_shop_cards(gs: dict[str, Any]) -> None:
         new_cards.append(card)
 
     gs["shop_cards"] = new_cards
+    # Pending edition tags also claim rerolled jokers (vanilla behavior).
+    _fire_shop_tags(gs, rerolled=True)
 
 
 def _get_card_set(card: Any) -> str:

--- a/jackdaw/engine/jokers.py
+++ b/jackdaw/engine/jokers.py
@@ -55,6 +55,7 @@ class GameSnapshot:
     mail_card_id: int | None = None
     idol_card: dict[str, Any] | None = None
     ancient_suit: str | None = None
+    castle_card_suit: str | None = None
     skips: int = 0
 
 
@@ -2420,7 +2421,11 @@ def _castle(card: Card, ctx: JokerContext) -> JokerResult | None:
     Fires in discard context.
     """
     if ctx.discard and ctx.other_card is not None and not ctx.blueprint:
-        castle_suit = card.ability.get("castle_card_suit")
+        # Suit lives on G.GAME.current_round.castle_card (card.lua:2857),
+        # not on the joker — read it from the game snapshot.
+        castle_suit = (ctx.game.castle_card_suit if ctx.game else None) or card.ability.get(
+            "castle_card_suit"
+        )
         if castle_suit and ctx.other_card.is_suit(castle_suit, smeared=ctx.smeared):
             extra = card.ability.get("extra", {})
             extra["chips"] = extra.get("chips", 0) + extra.get("chip_mod", 3)

--- a/jackdaw/engine/pools.py
+++ b/jackdaw/engine/pools.py
@@ -521,23 +521,22 @@ def _is_softlocked_planet(key: str, visible_hand_types: set[str]) -> bool:
     return hand_type not in visible_hand_types
 
 
+_SOFTLOCK_PLANETS: dict[str, str] = {
+    "c_planet_x": "Five of a Kind",
+    "c_ceres": "Flush House",
+    "c_eris": "Flush Five",
+}
+
+
 def _filter_planet(*, key: str, played_hand_types: set[str]) -> str:
-    """Exclude planet if its hand type has never been played (softlock guard).
+    """Exclude softlock planets until their hand type has been played this run.
 
-    The hand-type association is encoded in the planet key itself:
-    ``c_mercury`` → ``"High Card"``, etc.  We only apply the softlock filter
-    when ``played_hand_types`` is non-empty (caller opted in).
+    common_events.lua:2008-2011 gates only planets with ``config.softlock``
+    (Planet X / Ceres / Eris) on ``G.GAME.hands[hand_type].played > 0``.
+    All other planets are always eligible regardless of play history.
     """
-    if not played_hand_types:
-        return key
-
-    hand_type = _PLANET_HAND.get(key)
-    if hand_type is None:
-        # Unknown planet key — allow through
-        return key
-    if hand_type == "all":
-        return key
-    if hand_type not in played_hand_types:
+    hand_type = _SOFTLOCK_PLANETS.get(key)
+    if hand_type is not None and hand_type not in played_hand_types:
         return UNAVAILABLE
     return key
 

--- a/jackdaw/engine/round_lifecycle.py
+++ b/jackdaw/engine/round_lifecycle.py
@@ -204,10 +204,17 @@ def reset_round_targets(
         and ``deck`` list of Card objects.
     """
     cr = game_state["current_round"]
-    deck: list[Card] = game_state.get("deck", [])
+    # Vanilla iterates G.playing_cards — every playing card in the run
+    # regardless of zone (deck / hand / discard).  rng.element re-sorts by
+    # sort_id, so zone concatenation order is irrelevant.
+    all_cards: list[Card] = [
+        *game_state.get("deck", []),
+        *game_state.get("hand", []),
+        *game_state.get("discard_pile", []),
+    ]
 
     # Filter out Stone cards — only non-Stone playing cards are eligible
-    valid_cards = [c for c in deck if _card_effect(c) != "Stone Card"]
+    valid_cards = [c for c in all_cards if _card_effect(c) != "Stone Card"]
 
     # ------------------------------------------------------------------
     # reset_idol_card — common_events.lua:2271-2286

--- a/jackdaw/engine/round_lifecycle.py
+++ b/jackdaw/engine/round_lifecycle.py
@@ -213,8 +213,12 @@ def reset_round_targets(
         *game_state.get("discard_pile", []),
     ]
 
-    # Filter out Stone cards — only non-Stone playing cards are eligible
-    valid_cards = [c for c in all_cards if _card_effect(c) != "Stone Card"]
+    # Filter out Stone cards — only non-Stone playing cards are eligible.
+    # Also skip any card without a base (cannot occur in vanilla; defends
+    # the mail.base.id read below against sim-side creation bugs).
+    valid_cards = [
+        c for c in all_cards if _card_effect(c) != "Stone Card" and c.base is not None
+    ]
 
     # ------------------------------------------------------------------
     # reset_idol_card — common_events.lua:2271-2286

--- a/jackdaw/engine/run_init.py
+++ b/jackdaw/engine/run_init.py
@@ -416,12 +416,11 @@ def start_round(game_state: dict[str, Any]) -> None:
     if hand_levels is not None:
         hand_levels.reset_round_counts()
 
-    # Reset targeting cards (idol, mail, ancient, castle) — state_events.lua:273-276
-    # These are re-rolled every round from the current deck state.
-    rng = game_state.get("rng")
-    ante = rr.get("ante", 1)
-    if rng is not None:
-        reset_round_targets(rng, ante, game_state)
+    # NOTE: targeting cards (idol, mail, ancient, castle) are NOT re-rolled
+    # here.  Vanilla rolls them once at run start (game.lua:2385-2389) and
+    # then at each round END (state_events.lua:273-276) — never at round
+    # start.  Rolling here would double-advance the 'idol/mail/anc/cas'
+    # streams.  See _handle_cash_out in game.py for the round-end roll.
 
 
 # ---------------------------------------------------------------------------

--- a/jackdaw/env/action_space.py
+++ b/jackdaw/env/action_space.py
@@ -267,8 +267,22 @@ def get_action_mask(game_state: dict[str, Any]) -> ActionMask:
         # Spectral packs: balatrobot cannot handle Spectral card
         # highlighting via RPC, so only SkipPack is valid.
         if remaining > 0 and pack_cards and pack_type != "Spectral":
-            type_mask[ActionType.PickPackCard] = True
-            entity_masks[ActionType.PickPackCard] = np.ones(len(pack_cards), dtype=bool)
+            # Vanilla gate (button_callbacks.lua:2112): a Joker in a pack is
+            # selectable only if joker slots have room or it is negative.
+            pick_mask = np.ones(len(pack_cards), dtype=bool)
+            if len(game_state.get("jokers", [])) >= game_state.get("joker_slots", 5):
+                for i, card in enumerate(pack_cards):
+                    ability = getattr(card, "ability", None) or {}
+                    edition = getattr(card, "edition", None) or {}
+                    negative = (
+                        bool(edition.get("negative"))
+                        if isinstance(edition, dict) else False
+                    )
+                    if ability.get("set", "") == "Joker" and not negative:
+                        pick_mask[i] = False
+            if pick_mask.any():
+                type_mask[ActionType.PickPackCard] = True
+                entity_masks[ActionType.PickPackCard] = pick_mask
         type_mask[ActionType.SkipPack] = True
 
     return ActionMask(type_mask, card_mask, entity_masks, max_card_select, min_card_select)

--- a/tests/engine/test_tag_wiring.py
+++ b/tests/engine/test_tag_wiring.py
@@ -1,0 +1,94 @@
+"""Regression tests for skip-tag hook wiring and the pack joker-cap gate.
+
+Both bugs were found by LLM agents playing full runs (2026-07-20):
+- Deferred skip tags (store_joker_modify / eval / shop_start /
+  shop_final_pass) were awarded but never fired: populate_shop's "M11 tag
+  system" note deferred the hooks and nothing wired them.
+- Pack picks ignored the joker-slot cap (vanilla button_callbacks.lua:2112
+  gates non-negative Jokers when the board is full).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from jackdaw.env.action_space import ActionType, get_action_mask
+from jackdaw.engine.actions import GamePhase
+from jackdaw.engine.game import _fire_shop_tags, step
+from jackdaw.engine.run_init import initialize_run
+
+
+def _cheat_through_blind(gs) -> None:
+    from jackdaw.engine.actions import CashOut, PlayHand, SelectBlind
+
+    step(gs, SelectBlind())
+    gs["chips"] = 0
+    gs["current_round"]["hands_left"] = 4
+    # Force an instant clear by inflating chips post-selection.
+    gs["blind"].chips = 1
+    step(gs, PlayHand(card_indices=[0, 1, 2, 3, 4]))
+    step(gs, CashOut())
+
+
+class TestPackJokerCapGate:
+    def test_full_board_blocks_joker_picks(self):
+        gs = initialize_run("b_red", 1, "OVERFLOW1")
+        gs["phase"] = GamePhase.BLIND_SELECT
+        gs["blind_on_deck"] = "Small"
+        from jackdaw.engine.card_factory import create_joker
+
+        for key in ("j_joker", "j_greedy_joker", "j_lusty_joker",
+                    "j_wrathful_joker", "j_gluttenous_joker"):
+            gs["jokers"].append(create_joker(key))
+        assert len(gs["jokers"]) == 5
+
+        # Fabricate an open buffoon pack.
+        gs["phase"] = GamePhase.PACK_OPENING
+        gs["pack_type"] = "Buffoon"
+        gs["pack_choices_remaining"] = 1
+        gs["pack_cards"] = [
+            create_joker("j_fortune_teller"),
+            create_joker("j_walkie_talkie"),
+        ]
+        mask = get_action_mask(gs)
+        assert not mask.type_mask[ActionType.PickPackCard]
+
+        # Free a slot: picks become legal again.
+        gs["jokers"].pop()
+        mask = get_action_mask(gs)
+        assert mask.type_mask[ActionType.PickPackCard]
+        assert mask.entity_masks[ActionType.PickPackCard].all()
+
+
+class TestSkipTagWiring:
+    def test_polychrome_tag_fires_on_next_shop_joker(self):
+        # CLAUDEA2: ante-1 Big skip tag is tag_polychrome.
+        gs = initialize_run("b_red", 1, "CLAUDEA2")
+        gs["phase"] = GamePhase.BLIND_SELECT
+        gs["blind_on_deck"] = "Small"
+        assert gs["round_resets"]["blind_tags"]["Big"] == "tag_polychrome"
+
+        _cheat_through_blind(gs)  # beat Small, now in shop
+        from jackdaw.engine.actions import NextRound, SkipBlind
+
+        step(gs, NextRound())
+        step(gs, SkipBlind())  # Big skipped -> polychrome tag awarded
+        _cheat_through_blind(gs)  # beat Boss -> next shop generated
+
+        jokers = [c for c in gs["shop_cards"]
+                  if (getattr(c, "ability", None) or {}).get("set") == "Joker"]
+        assert jokers, "expected a joker in the post-skip shop"
+        tagged = [c for c in jokers if (getattr(c, "edition", None) or {}).get("polychrome")]
+        assert tagged, "polychrome tag should mark the next base shop joker"
+        assert tagged[0].cost == 0  # vanilla: tag-edition jokers are free
+
+    def test_shop_tags_do_not_refire(self):
+        gs = initialize_run("b_red", 1, "CLAUDEA2")
+        gs["awarded_tags"] = [{"key": "tag_polychrome", "blind": "Big"}]
+        from jackdaw.engine.card_factory import create_joker
+
+        gs["shop_cards"] = [create_joker("j_joker")]
+        _fire_shop_tags(gs, rerolled=False)
+        assert gs["awarded_tags"][0]["shop_fired"]
+        gs["shop_cards"] = [create_joker("j_sly")]
+        _fire_shop_tags(gs, rerolled=False)
+        assert not (getattr(gs["shop_cards"][0], "edition", None) or {})

--- a/tests/fixtures/cross_validation/shop.json
+++ b/tests/fixtures/cross_validation/shop.json
@@ -106,7 +106,7 @@
           "set": "Planet"
         },
         {
-          "key": "c_uranus",
+          "key": "c_neptune",
           "cost": 3,
           "set": "Planet"
         }
@@ -143,7 +143,7 @@
           "set": "Tarot"
         },
         {
-          "key": "c_eris",
+          "key": "c_uranus",
           "cost": 3,
           "set": "Planet"
         }
@@ -156,7 +156,7 @@
       "voucher": "v_hieroglyph",
       "jokers": [
         {
-          "key": "c_ceres",
+          "key": "c_pluto",
           "cost": 3,
           "set": "Planet"
         },

--- a/tests/fixtures/shop_oracle_TESTSEED.json
+++ b/tests/fixtures/shop_oracle_TESTSEED.json
@@ -42,7 +42,7 @@
           "rental": true
         },
         {
-          "center_key": "c_ceres",
+          "center_key": "c_saturn",
           "set": "Planet"
         }
       ],
@@ -68,7 +68,7 @@
           "set": "Tarot"
         },
         {
-          "center_key": "c_eris",
+          "center_key": "c_uranus",
           "set": "Planet"
         }
       ],


### PR DESCRIPTION
## Note: stacks on #2

This branch is based on `live-validated-engine-fixes` (#2) because the Certificate/Marble fix uses the pool-roll machinery introduced there. **Only the last two commits are new**; they'll rebase cleanly once #2 merges. Happy to restructure if you'd prefer a different arrangement.

## What's fixed

Both bugs were found by LLM agents playing full runs through the simulator (deep-state reachability the scenario suite doesn't cover).

### 1. Certificate/Marble Joker created front-less playing cards
Their created cards never rolled a front (suit/rank), leaving `card.base = None`, which corrupted the playing-card pool and crashed round-end targeting rolls (`mail.base.id`). Now rolls fronts vanilla-faithfully via the `cert_fr`/`marb_fr` streams (card.lua:2462/2580), including Certificate's seal roll (`certsl`) and its deal-to-hand behavior mid-round.

### 2. Deferred skip-tag hooks were never wired; pack picks ignored the joker cap
- `populate_shop` carries a note deferring tag hooks "to the M11 tag system" — `tags.py` implements every effect, but nothing ever called the shop-side contexts, so Foil/Holo/Polychrome/Negative/Coupon/D6/Investment tags were awarded and silently did nothing. Now wired: `store_joker_modify` (next base-edition shop Joker gains the edition and becomes free, on shop entry and rerolls, consumed FIFO), `shop_final_pass` (Coupon), `shop_start` (D6 free rerolls), and `eval` (Investment pays $25 at cash-out after a boss). `store_joker_create` (Rare/Uncommon) and `voucher_add` are deliberately left unwired with a code comment: both replace RNG-consuming creation rolls and deserve live validation before a faithful port.
- With a full joker board, a Joker could still be taken from a Buffoon pack (6- and 7-joker boards observed in play). Vanilla gates selection unless a slot is free or the Joker is negative (button_callbacks.lua:2112-2113); now gated in both the env action mask and the engine legal-action list.

### Also investigated, not a bug
Late-run Celestial packs full of duplicate Plutos are vanilla-faithful: once every planet has been created, the exhausted-pool fallback is the hardcoded `"c_pluto"` (common_events.lua:2042).

## Tests

3 new regression tests (`tests/engine/test_tag_wiring.py`) incl. an end-to-end skip→polychrome-shop-joker check; full suite passes (1,483 + new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oGfm3wSmd1YoYmERrugsi
