### PR TITLE
fix: include engine data JSONs in wheels via package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["jackdaw*"]
 
+[tool.setuptools.package-data]
+jackdaw = ["engine/data/*.json"]
+
 [project.scripts]
 jackdaw = "jackdaw.cli.main:main"
 


### PR DESCRIPTION
Non-editable installs (`pip install git+https://...` or from a built wheel/sdist) fail at import time:

```
FileNotFoundError: ... site-packages/jackdaw/engine/data/centers.json
```

The setuptools config declares `packages.find` but no package data, so all six `*.json` files under `jackdaw/engine/data/` are dropped from the wheel. Editable installs mask this by reading straight from the source tree, which is why development setups never hit it.

Fix: declare them via `[tool.setuptools.package-data]`. Verified with `uv build --wheel` — all six JSONs (blinds, cards, centers, seals, stakes, tags) now land in the wheel, and a git install imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

