### PR TITLE
perf: hoist get_id out of get_x_same's O(n^2) loop; compute hand analysis once per observation

### DIFF
--- a/jackdaw/engine/hand_eval.py
+++ b/jackdaw/engine/hand_eval.py
@@ -151,11 +151,14 @@ def get_x_same(num: int, hand: list[Card]) -> list[list[Card]]:
     # vals[id] = list of cards with that id, only if count == num
     vals: dict[int, list[Card]] = {}
 
+    # get_id is pure (stone cards return a fixed -1 placeholder), so it can
+    # be hoisted out of the O(n^2) comparison loop.
+    ids = [c.get_id() for c in hand]
     for i in range(len(hand) - 1, -1, -1):
         curr = [hand[i]]
-        card_id = hand[i].get_id()
+        card_id = ids[i]
         for j in range(len(hand)):
-            if hand[i].get_id() == hand[j].get_id() and i != j:
+            if ids[i] == ids[j] and i != j:
                 curr.append(hand[j])
         if len(curr) == num:
             vals[card_id] = curr

--- a/jackdaw/env/observation.py
+++ b/jackdaw/env/observation.py
@@ -676,8 +676,15 @@ def _analyze_draws(hand: list[Card]) -> _DrawAnalysis:
     )
 
 
-def encode_global_context(gs: dict[str, Any]) -> np.ndarray:
+def encode_global_context(
+    gs: dict[str, Any],
+    hand_analysis: tuple[np.ndarray, str, set[int]] | None = None,
+) -> np.ndarray:
     """Encode the fixed-size global context vector.
+
+    ``hand_analysis`` accepts a precomputed ``_compute_hand_analysis``
+    result for the live hand, so a caller that also encodes the hand
+    cards (which need the same analysis) can compute it once.
 
     Returns shape ``(D_GLOBAL,)`` float32 array (230 features).
 
@@ -827,10 +834,10 @@ def encode_global_context(gs: dict[str, Any]) -> np.ndarray:
     hand_levels: HandLevels | None = gs.get("hand_levels")
 
     # Hand type indicators + best hand analysis [211:223]
-    hand_type_vec, best_hand_name, _scoring_ids = _compute_hand_analysis(
-        hand,
-        jokers,
-        hand_levels,
+    hand_type_vec, best_hand_name, _scoring_ids = (
+        hand_analysis
+        if hand_analysis is not None
+        else _compute_hand_analysis(hand, jokers, hand_levels)
     )
     v[sbase : sbase + NUM_HAND_TYPES] = hand_type_vec
 
@@ -964,11 +971,16 @@ def _get_joker_buf(n: int) -> np.ndarray:
 def encode_playing_cards_batch(
     cards: list[Card],
     gs: dict[str, Any],
+    hand_analysis: tuple[np.ndarray, str, set[int]] | None = None,
 ) -> np.ndarray:
     """Encode multiple playing cards into a single array.
 
     Returns shape ``(len(cards), D_PLAYING_CARD)`` float32 array.
     Uses pre-allocated buffer to avoid per-call allocation.
+
+    ``hand_analysis`` accepts a precomputed ``_compute_hand_analysis``
+    result for *these* cards; pass it only when it was computed over the
+    same card list (the live hand), never for other areas (pack cards).
     """
     n = len(cards)
     if n == 0:
@@ -978,7 +990,11 @@ def encode_playing_cards_batch(
 
     # Compute which cards belong to the best detected hand
     jokers: list[Card] = gs.get("jokers", [])
-    _, _, scoring_ids = _compute_hand_analysis(cards, jokers, gs.get("hand_levels"))
+    _, _, scoring_ids = (
+        hand_analysis
+        if hand_analysis is not None
+        else _compute_hand_analysis(cards, jokers, gs.get("hand_levels"))
+    )
 
     for i, card in enumerate(cards):
         row = buf[i]  # already zeroed
@@ -1113,15 +1129,21 @@ def encode_observation(gs: dict[str, Any]) -> Observation:
     Observation
         Entity-based observation with variable-length arrays.
     """
+    # The best-hand analysis over the live hand is needed twice — by the
+    # global context (hand-type indicators, base score) and by the hand
+    # rows (scoring-card flags) — and it dominates encoding cost; compute
+    # it once and thread it through.
+    hand: list[Card] = gs.get("hand", [])
+    jokers: list[Card] = gs.get("jokers", [])
+    hand_analysis = _compute_hand_analysis(hand, jokers, gs.get("hand_levels"))
+
     # Global context
-    global_ctx = encode_global_context(gs)
+    global_ctx = encode_global_context(gs, hand_analysis=hand_analysis)
 
     # Hand cards — batch encode
-    hand: list[Card] = gs.get("hand", [])
-    hand_arr = encode_playing_cards_batch(hand, gs)
+    hand_arr = encode_playing_cards_batch(hand, gs, hand_analysis=hand_analysis)
 
     # Jokers — batch encode
-    jokers: list[Card] = gs.get("jokers", [])
     joker_arr = encode_jokers_batch(jokers, gs)
 
     # Consumables (small count, keep per-card)


### PR DESCRIPTION
Two exact-output optimizations on the RL hot path, found by cProfile on AlphaZero-style self-play (the observation encoder accounted for ~30% of per-move cost; 4.78M `Card.get_id` calls per two games traced to two sources):

1. **`hand_eval.get_x_same`** called `hand[i].get_id()`/`hand[j].get_id()` inside the pairwise comparison loop — ~128 calls per invocation on an 8-card hand, ×4 invocations per `evaluate_poker_hand`. `get_id` is pure (stone cards return a fixed -1 placeholder, per the card.py docstring), so the ids are now hoisted into one list per call. Group construction order is untouched (matches `get_X_same`, misc_functions.lua:592).

2. **`encode_observation`** ran `_compute_hand_analysis` twice per state on identical inputs — once in `encode_global_context` (hand-type indicators, base score) and once in `encode_playing_cards_batch` (scoring-card flags). Both encoders now accept an optional precomputed `hand_analysis`; `encode_observation` computes it once and threads it through. The `pack_cards` call site deliberately does NOT receive it (its analysis runs over the pack's dealt cards, not the live hand). Default-None keeps every other caller byte-identical.

Verified: full suite 1575 green, `ruff check` + `ruff format --check` clean; fixed-seed A/B on our downstream agent replays identical trajectories (417 moves, same antes/progress), so output is exact — this is throughput only (~1.5x on our self-play combined with agent-side changes).

Independent of #10 (touches engine/env code only, no overlap with the packaging fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

