### PR TITLE
fix: sold jokers fire selling_self — Luchador, Invisible, Diet Cola

### DIFF
--- a/jackdaw/engine/game.py
+++ b/jackdaw/engine/game.py
@@ -415,6 +415,28 @@ def _open_tag_pack(gs: dict[str, Any], pack_key: str, force: bool = False) -> No
     gs["phase"] = GamePhase.PACK_OPENING
 
 
+def _award_tag(gs: dict[str, Any], tag_key: str, source: str) -> None:
+    """Grant one tag, mirroring live ``add_tag`` (UI_definitions.lua:1252).
+
+    Tags live in ``awarded_tags`` as ``{"key", "result", "blind"}`` records;
+    ``gs["tags"]`` is a phantom key nothing reads.  Every grant runs the
+    ``immediate`` hook and applies its result, so callers never rebuild the
+    record shape by hand.  ``source`` labels the provenance ("Small"/"Big"
+    for skips, otherwise the granting card).
+
+    Callers own the ``_check_double_tag`` call: the skip path defers it until
+    after ``blind_on_deck`` advances (button_callbacks.lua:2740-2775).
+    """
+    from jackdaw.engine.tags import Tag
+
+    tag_result = Tag(tag_key).apply("immediate", gs, rng=gs.get("rng"))
+    gs.setdefault("awarded_tags", []).append(
+        {"key": tag_key, "result": tag_result, "blind": source}
+    )
+    if tag_result is not None:
+        _apply_tag_result(gs, tag_result)
+
+
 def _apply_tag_result(gs: dict[str, Any], result: Any) -> None:
     """Apply a TagResult's effects to the game state.
 
@@ -489,25 +511,12 @@ def _handle_skip_blind(gs: dict[str, Any]) -> dict[str, Any]:
     # ------------------------------------------------------------------
     blind_tags = rr.get("blind_tags", {})
     tag_key = blind_tags.get(blind_on_deck)
-    awarded_tags: list[dict[str, Any]] = gs.setdefault("awarded_tags", [])
+    # Keep the key present even when this blind carries no tag (shape-stable
+    # for get_state/load_state); _award_tag setdefaults it again when it does.
+    gs.setdefault("awarded_tags", [])
 
     if tag_key:
-        from jackdaw.engine.tags import Tag
-
-        tag = Tag(tag_key)
-        tag_result = tag.apply("immediate", gs, rng=gs.get("rng"))
-
-        awarded_tags.append(
-            {
-                "key": tag_key,
-                "result": tag_result,
-                "blind": blind_on_deck,
-            }
-        )
-
-        # Apply immediate tag effects
-        if tag_result is not None:
-            _apply_tag_result(gs, tag_result)
+        _award_tag(gs, tag_key, source=blind_on_deck)
 
     # ------------------------------------------------------------------
     # 4. Fire joker skip_blind context
@@ -1273,6 +1282,11 @@ def _handle_sell_card(gs: dict[str, Any], area: str, idx: int) -> dict[str, Any]
     if getattr(card, "eternal", False):
         raise IllegalActionError("Cannot sell eternal card")
 
+    # Live Card:sell_card dispatches selling_self before the sold card is
+    # removed (card.lua:1599). Apply the returned mutation at that point too.
+    selling_self_mutations = _fire_selling_self(gs, card)
+    _apply_selling_self_mutations(gs, card, selling_self_mutations)
+
     gs["dollars"] = gs.get("dollars", 0) + card.sell_cost
     cards.pop(idx)
     card.remove_from_deck(gs)
@@ -1288,6 +1302,90 @@ def _handle_sell_card(gs: dict[str, Any], area: str, idx: int) -> dict[str, Any]
     _fire_shop_joker_context(gs, selling_card=True)
 
     return gs
+
+
+def _fire_selling_self(gs: dict[str, Any], card: Any) -> list[dict[str, Any]]:
+    """Dispatch ``selling_self`` for the sold card while it remains owned."""
+    from jackdaw.engine.jokers import GameSnapshot, JokerContext, calculate_joker
+
+    jokers: list = gs.get("jokers", [])
+    cr = gs.get("current_round", {})
+    result = calculate_joker(
+        card,
+        JokerContext(
+            selling_self=True,
+            blind=gs.get("blind"),
+            jokers=jokers,
+            game=GameSnapshot(
+                joker_count=len(jokers),
+                joker_slots=gs.get("joker_slots", 5),
+                money=gs.get("dollars", 0),
+                hands_played=cr.get("hands_played", 0),
+                discards_used=cr.get("discards_used", 0),
+            ),
+            rng=gs.get("rng"),
+        ),
+    )
+    if result and result.extra:
+        return [result.extra]
+    return []
+
+
+def _apply_selling_self_mutations(
+    gs: dict[str, Any],
+    sold_card: Any,
+    mutations: list[dict[str, Any]],
+) -> None:
+    """Apply Luchador, Invisible Joker, and Diet Cola sell effects."""
+    for mutation in mutations:
+        if mutation.get("disable_blind"):
+            _disable_active_blind(gs)
+
+        if mutation.get("duplicate_random_joker"):
+            jokers: list = gs.get("jokers", [])
+            candidates = [joker for joker in jokers if joker is not sold_card]
+            rng = gs.get("rng")
+            if candidates and len(jokers) <= gs.get("joker_slots", 5) and rng is not None:
+                import copy
+
+                chosen, _ = rng.element(candidates, rng.seed("invisible"))
+                duplicate = copy.deepcopy(chosen)
+                if "invis_rounds" in duplicate.ability:
+                    duplicate.ability["invis_rounds"] = 0
+                duplicate.add_to_deck(gs)
+                jokers.append(duplicate)
+
+        create = mutation.get("create", {})
+        if create.get("type") == "Tag":
+            # Diet Cola: live wraps add_tag(Tag('tag_double')) in an event
+            # (card.lua:2361), but the tag is held with no immediate effect,
+            # so the deferral is unobservable and is not modelled.
+            tag_key = create["key"]
+            _award_tag(gs, tag_key, source=getattr(sold_card, "center_key", "sell"))
+            # Live add_tag fires tag_add on every held tag; a held Double
+            # never duplicates another Double (tag.lua:320), so this is inert
+            # for Diet Cola itself and guards any future tag-creating joker.
+            _check_double_tag(gs, tag_key)
+
+
+def _disable_active_blind(gs: dict[str, Any]) -> None:
+    """Disable the current blind and apply its returned restorations."""
+    blind = gs.get("blind")
+    if blind is None:
+        return
+
+    playing_cards = []
+    for area in ("deck", "hand", "play", "discard_pile"):
+        playing_cards.extend(gs.get(area, []))
+    effects = blind.disable(playing_cards=playing_cards, joker_cards=gs.get("jokers", []))
+
+    cr = gs.get("current_round", {})
+    cr["discards_left"] = cr.get("discards_left", 0) + effects.get("restore_discards", 0)
+    cr["hands_left"] = cr.get("hands_left", 0) + effects.get("restore_hands", 0)
+    gs["hand_size"] = gs.get("hand_size", 0) + effects.get("restore_hand_size", 0)
+    if effects.get("clear_forced"):
+        for card in playing_cards:
+            card.ability.pop("forced_selection", None)
 
 
 def _handle_use_consumable(

--- a/tests/engine/test_game.py
+++ b/tests/engine/test_game.py
@@ -29,6 +29,7 @@ from jackdaw.engine.actions import (
     UseConsumable,
     get_legal_actions,
 )
+from jackdaw.engine.blind import Blind
 from jackdaw.engine.card import Card
 from jackdaw.engine.game import IllegalActionError, step
 from jackdaw.engine.run_init import initialize_run
@@ -214,6 +215,252 @@ class TestSellCard:
         gs["jokers"] = [_joker_card(eternal=True)]
         with pytest.raises(IllegalActionError, match="eternal"):
             step(gs, SellCard(area="jokers", card_index=0))
+
+    def test_selling_luchador_disables_boss_blind(self):
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SELECTING_HAND
+        boss = Blind.create("bl_water", ante=1)
+        boss.discards_sub = 2
+        gs["blind"] = boss
+        gs["current_round"]["discards_left"] = 1
+        luchador = Card()
+        luchador.set_ability("j_luchador")
+        luchador.center_key = "j_luchador"
+        luchador.sell_cost = 4
+        gs["jokers"] = [luchador]
+
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        assert boss.disabled is True
+        assert gs["current_round"]["discards_left"] == 3
+        assert len(gs["jokers"]) == 0
+
+    def test_selling_luchador_restores_manacle_hand_size(self):
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SELECTING_HAND
+        boss = Blind.create("bl_manacle", ante=1)
+        gs["blind"] = boss
+        gs["hand_size"] = 7
+        luchador = Card()
+        luchador.set_ability("j_luchador")
+        luchador.center_key = "j_luchador"
+        luchador.sell_cost = 4
+        gs["jokers"] = [luchador]
+
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        assert boss.disabled is True
+        assert gs["hand_size"] == 8
+        assert len(gs["jokers"]) == 0
+
+    def test_selling_luchador_during_non_boss_blind(self):
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SELECTING_HAND
+        small = Blind.create("bl_small", ante=1)
+        gs["blind"] = small
+        luchador = Card()
+        luchador.set_ability("j_luchador")
+        luchador.center_key = "j_luchador"
+        luchador.sell_cost = 4
+        gs["jokers"] = [luchador]
+
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        assert small.disabled is False
+        assert len(gs["jokers"]) == 0
+
+    @staticmethod
+    def _diet_cola() -> Card:
+        cola = Card()
+        cola.set_ability("j_diet_cola")
+        cola.center_key = "j_diet_cola"
+        cola.sell_cost = 2
+        return cola
+
+    def test_selling_diet_cola_awards_a_double_tag(self):
+        """The tag must land in awarded_tags — the list the engine consumes.
+
+        gs["tags"] is a phantom key nothing reads (see _check_double_tag's
+        BUG HISTORY note), so asserting against it would pass while the
+        player received nothing.
+        """
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        gs["jokers"] = [self._diet_cola()]
+
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        assert [a["key"] for a in gs["awarded_tags"]] == ["tag_double"]
+
+    def test_diet_cola_double_duplicates_the_next_skip_tag(self):
+        """End-to-end: the awarded Double actually cashes in on a skip.
+
+        Skips and Diet Cola are the only tag sources, so this is the whole
+        observable payout path.
+        """
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        gs["jokers"] = [self._diet_cola()]
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        gs["phase"] = GamePhase.BLIND_SELECT
+        gs["round_resets"]["blind_tags"]["Small"] = "tag_economy"
+        step(gs, SkipBlind())
+
+        awarded = gs["awarded_tags"]
+        assert [a["key"] for a in awarded].count("tag_economy") == 2
+        assert not [a for a in awarded if a["key"] == "tag_double"]
+
+    def test_selling_diet_cola_mid_blind_awards_the_tag(self):
+        """Selling is not shop-only; the tag lands the same during a blind."""
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SELECTING_HAND
+        gs["jokers"] = [self._diet_cola()]
+
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        assert [a["key"] for a in gs["awarded_tags"]] == ["tag_double"]
+
+    def test_two_diet_colas_triple_the_next_skip_tag(self):
+        """Each Double contributes exactly one copy: 2 Doubles + 1 tag = 3."""
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        gs["jokers"] = [self._diet_cola(), self._diet_cola()]
+        step(gs, SellCard(area="jokers", card_index=0))
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        gs["phase"] = GamePhase.BLIND_SELECT
+        gs["round_resets"]["blind_tags"]["Small"] = "tag_economy"
+        step(gs, SkipBlind())
+
+        assert [a["key"] for a in gs["awarded_tags"]].count("tag_economy") == 3
+
+    def test_selling_invisible_joker_duplicates_another_joker(self):
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        original = Card()
+        original.set_ability("j_joker")
+        original.center_key = "j_joker"
+        invisible = Card()
+        invisible.set_ability("j_invisible")
+        invisible.center_key = "j_invisible"
+        invisible.ability["invis_rounds"] = invisible.ability["extra"]
+        gs["jokers"] = [original, invisible]
+
+        step(gs, SellCard(area="jokers", card_index=1))
+
+        assert [joker.center_key for joker in gs["jokers"]] == ["j_joker", "j_joker"]
+        assert gs["jokers"][0] is original
+        assert gs["jokers"][1] is not original
+        assert "invisible" in gs["rng"].get_state()
+
+    @staticmethod
+    def _ripe_invisible() -> Card:
+        """An Invisible Joker that has met its round threshold."""
+        inv = Card()
+        inv.set_ability("j_invisible")
+        inv.center_key = "j_invisible"
+        inv.ability["invis_rounds"] = inv.ability["extra"]
+        return inv
+
+    def test_unripe_invisible_joker_does_not_duplicate(self):
+        """invis_rounds below extra: no copy, and the RNG stream is untouched.
+
+        Live only reaches pseudoseed('invisible') inside the duplication
+        branch (card.lua:2382), so a premature sell must not advance it.
+        """
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        original = Card()
+        original.set_ability("j_joker")
+        original.center_key = "j_joker"
+        invisible = self._ripe_invisible()
+        invisible.ability["invis_rounds"] = invisible.ability["extra"] - 1
+        gs["jokers"] = [original, invisible]
+
+        step(gs, SellCard(area="jokers", card_index=1))
+
+        assert [j.center_key for j in gs["jokers"]] == ["j_joker"]
+        assert "invisible" not in gs["rng"].get_state()
+
+    def test_lone_invisible_joker_has_nothing_to_duplicate(self):
+        """No other joker to copy (card.lua:2388 k_no_other_jokers)."""
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        gs["jokers"] = [self._ripe_invisible()]
+
+        step(gs, SellCard(area="jokers", card_index=0))
+
+        assert gs["jokers"] == []
+        assert "invisible" not in gs["rng"].get_state()
+
+    @staticmethod
+    def _plain_joker() -> Card:
+        j = Card()
+        j.set_ability("j_joker")
+        j.center_key = "j_joker"
+        j.sell_cost = 3
+        return j
+
+    def test_negative_invisible_joker_at_cap_duplicates_and_overshoots_slots(self):
+        """A Negative Invisible Joker's own edition earns the slot it needs.
+
+        At 6 jokers / 6 slots (5 base + 1 from this card's own Negative
+        edition) you are legitimately at cap, not already over it.  Selling
+        fires selling_self BEFORE this card's own slot bonus is removed
+        (card.lua:1599 vs card.lua:648's remove_from_deck), so the duplicate
+        check still sees room -- live gates on ``<=`` counting the sold card
+        (card.lua:2379) -- and fires.  Removing the sold card afterward drops
+        joker_slots back to 5: one card duplicated, one slot bonus lost,
+        landing at 6 jokers / 5 slots.
+        """
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        invisible = self._ripe_invisible()
+        invisible.edition = {"negative": True}
+        invisible.add_to_deck(gs)  # earns its own +1 slot, as a real acquisition would
+        assert gs["joker_slots"] == 6
+        gs["jokers"] = [*[self._plain_joker() for _ in range(5)], invisible]
+
+        step(gs, SellCard(area="jokers", card_index=5))
+
+        assert [j.center_key for j in gs["jokers"]] == ["j_joker"] * 6
+        assert gs["joker_slots"] == 5
+
+    def test_invisible_joker_over_slot_limit_does_not_duplicate(self):
+        """Over cap (6 jokers / 5 slots), the duplicate does not fire.
+
+        This is the state the test above *creates*: selling a Negative
+        Invisible Joker duplicates and simultaneously surrenders its slot
+        bonus.  Selling a second ripe Invisible from there hits live's
+        k_no_room_ex branch (card.lua:2385).  Reaching it this way rather
+        than by hand-setting joker_slots keeps the precondition one the
+        engine can actually produce.
+
+        Real-play provenance (mine): needs Showman plus a *second, naturally
+        rolled* Negative Invisible Joker -- Invisible Joker is Rare, so
+        without Showman the used_jokers gate (pools.py:388) forbids the
+        duplicate roll.  Selling the first Negative duplicates and
+        surrenders its slot, leaving 7 jokers against 6 slots; the second
+        sell then finds no room.  Constructed minimally here.
+        """
+        gs = _init_gs()
+        gs["phase"] = GamePhase.SHOP
+        negative = self._ripe_invisible()
+        negative.edition = {"negative": True}
+        negative.add_to_deck(gs)
+        second = self._ripe_invisible()
+        gs["jokers"] = [*[self._plain_joker() for _ in range(4)], negative, second]
+
+        step(gs, SellCard(area="jokers", card_index=4))
+        assert len(gs["jokers"]) == 6
+        assert gs["joker_slots"] == 5  # over cap, legitimately
+
+        idx = [j.center_key for j in gs["jokers"]].index("j_invisible")
+        step(gs, SellCard(area="jokers", card_index=idx))
+
+        # One card left, none gained: the no-room branch declined to copy.
+        assert len(gs["jokers"]) == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What's broken

Selling Luchador, Invisible Joker, or Diet Cola through `step(SellCard)` does nothing at all.
Luchador doesn't disable the boss blind, Invisible Joker doesn't duplicate, Diet Cola doesn't
create its Double Tag — between them, the entire text of those three cards.

## Root cause

The handlers are present and correct in `jokers.py` (`j_luchador`, `j_invisible`, `j_diet_cola`).
The agent-facing sell path simply never dispatched the context that reaches them:
`_handle_sell_card` broadcast only `selling_card`, and only *after* removing the sold card, so
every `selling_self` descriptor was dead-lettered.

**This is caller wiring, not missing joker semantics** — worth stating precisely, because the
joker-side implementation is already here and correct.

## What this changes

`_handle_sell_card` now dispatches `selling_self` while the card is still owned, and consumes the
returned descriptors. Live fires `calculate_joker{selling_self = true}` **synchronously** at
`card.lua:1599`, before the queued dissolve that removes the card, so the sell-side branches at
`card.lua:2354-2392` still see the card owned and still counted against the joker limit. That
ordering is load-bearing for Invisible Joker: the room check is `<=` and counts the card being
sold (`card.lua:2379`).

Tag grants are factored into a single `_award_tag` helper. Tags are consumed from `awarded_tags`
as `{"key", "result", "blind"}` records; `gs["tags"]` is a phantom key nothing reads. Writing a
Double Tag there leaves Diet Cola silently broken — the same failure mode `_check_double_tag`'s
own `BUG HISTORY` note records from the other direction (seed `LSVZ27Z7`, where Double Tag never
duplicated anything).

## Testing

Tests assert observable outcomes rather than storage — a test that checks where a value was
written rather than what it did cannot fail when the write goes somewhere nothing reads.

- **Luchador** — boss blind disabled; The Manacle's hand size restored; a non-boss blind left alone.
- **Invisible Joker** — duplicates when ripe; does *not* when unripe, when it's the only joker, or
  when over the slot limit. Each negative case also asserts the `invisible` RNG stream was not
  advanced, matching live only reaching `pseudoseed('invisible')` inside the duplication branch.
- **Diet Cola** — the tag lands in `awarded_tags`; it duplicates the next skip tag end-to-end;
  it works mid-blind as well as in the shop; two Doubles yield three copies.

`pytest tests/` → 1573 passed, 14 skipped. `ruff check` and `ruff format --check` clean.

## How this was verified

Every mechanic here was cross-referenced against the **game's own Lua source**, not against the
simulator's existing behavior — the anchors are cited inline above and in the commit so they can
be spot-checked. Where the two disagreed, the Lua won. The behaviors were also checked against
first-hand play knowledge from a Balatro player on our side, which is what settled several
questions the source alone left ambiguous:

- Diet Cola's Double lands **immediately** on sell and waits for the next non-Double tag, so the
  event deferral in `card.lua:2361` is unobservable and is deliberately not modelled.
- Skips and Diet Cola are the **only** two tag sources, which is why `_check_double_tag` being
  wired solely into the skip path is complete coverage rather than a gap.
- Two Doubles plus one incoming tag yields three copies total — each Double contributes exactly
  one — which matches the existing flat loop in `_check_double_tag`, so that code is untouched.
- Selling is essentially never phase-restricted, hence the mid-blind Diet Cola test alongside the
  shop one.

Two things we checked and deliberately did **not** change:

- **Tag generation.** Since this touches tag creation, we double-checked the tag pool and
  generation path against `game.lua:225-248` and `common_events.lua:2034`. It looks solid — no
  change proposed, mentioned only so nobody repeats the check.
- An earlier draft of the over-slot-limit test reached its precondition by hand-setting
  `joker_slots`, a state the engine cannot actually produce. It was replaced with one that gets
  there through a Negative Invisible Joker's own slot bonus — the mechanism that genuinely
  creates it.

## Scope of what's verified

**Verified against the Lua source and in-simulator only. There is no live capture behind any of
it.** These tests establish simulator behavior and sim-to-sim reproducibility; they do not
establish live-game equivalence. The live claims rest on reading `card.lua` / `blind.lua` /
`tag.lua`, not on a witnessed run.

One test — Invisible Joker over the slot limit — covers a state that is reachable but has,
as far as we know, never been produced in real play. It requires Showman plus a second, naturally
rolled Negative Invisible Joker. It is included because the ordering it pins is read directly off
`card.lua:1599` → `4727` → `645`, not inferred; reviewers who'd rather not carry an unwitnessed
case should feel free to ask for it to be dropped.

## Deliberately out of scope

- **`shop.sell_card`** has the identical gap (`shop.py:784` calls `calculate_joker` and discards
  the result) and no production caller. Left untouched as a separate API question rather than
  silently redesigned. Happy to follow up either way.
- **Chicot** reaches `blind.disable()` by a different path (`game.py:2251`) that skips the
  restorations. Real divergence from live, where Chicot and Luchador call the same
  `Blind:disable()` — but it's a separate fix, entangled with `setting_blind` round-counter
  handling.

## Reviewer judgment calls

- `_award_tag` is extracted from `_handle_skip_blind`, so this diff touches that function. The
  extraction is behavior-preserving (same operations, same order; the skip path keeps its own
  `_check_double_tag` call at its existing position). Rationale: duplicating the record shape
  inline is exactly what produced this bug in both directions. Easy to inline again if you'd
  rather keep the diff narrower.
- `_award_tag`'s `source` argument lands in a field named `"blind"`, which now reads oddly for
  non-skip grants like Diet Cola. Nothing consumes that field; renaming it would touch the record
  shape everywhere, so it's left alone here.
