### PR TITLE
Fix initialized stake flags for joker sticker generation

### DIFF
--- a/jackdaw/engine/card_factory.py
+++ b/jackdaw/engine/card_factory.py
@@ -304,6 +304,9 @@ def create_card(
         Modifier-enable keys:
         ``enable_eternals_in_shop`` (bool), ``enable_perishables_in_shop``
         (bool), ``enable_rentals_in_shop`` (bool).
+        Read from ``modifiers`` (the normal run state), with top-level
+        values as a fallback for direct callers. Nested values take
+        precedence, including explicit ``False``.
 
         Edition key:
         ``edition_rate`` (float, default 1.0).
@@ -421,9 +424,16 @@ def create_card(
         # Eternal / Perishable / Rental rolls are SHOP/PACK-area-gated
         # (common_events.lua:2137-2146)...
         if area in ("shop", "pack"):
-            enable_eternals = gs.get("enable_eternals_in_shop", False)
-            enable_perishables = gs.get("enable_perishables_in_shop", False)
-            enable_rentals = gs.get("enable_rentals_in_shop", False)
+            modifiers = gs.get("modifiers", {})
+            enable_eternals = modifiers.get(
+                "enable_eternals_in_shop", gs.get("enable_eternals_in_shop", False)
+            )
+            enable_perishables = modifiers.get(
+                "enable_perishables_in_shop", gs.get("enable_perishables_in_shop", False)
+            )
+            enable_rentals = modifiers.get(
+                "enable_rentals_in_shop", gs.get("enable_rentals_in_shop", False)
+            )
 
             # -- Eternal / Perishable (shared roll) --
             ep_roll = rng.random(_EP_KEY[area] + str(ante))

--- a/tests/engine/test_stake_sticker_wiring.py
+++ b/tests/engine/test_stake_sticker_wiring.py
@@ -1,0 +1,106 @@
+"""Stake initialization must enable shop/pack stickers through the normal state."""
+
+from __future__ import annotations
+
+import pytest
+
+from jackdaw.engine.card_factory import create_card
+from jackdaw.engine.rng import PseudoRandom
+from jackdaw.engine.run_init import initialize_run
+
+
+@pytest.mark.parametrize("stake", range(1, 9))
+@pytest.mark.parametrize(
+    "area,ep_key,rental_key",
+    [
+        ("shop", "etperpoll1", "ssjr1"),
+        ("pack", "packetper1", "packssjr1"),
+    ],
+)
+@pytest.mark.parametrize(
+    "ep_roll,rental_roll",
+    [
+        (0.8, 0.8),
+        (0.5, 0.8),
+        (0.4, 0.7),
+        (0.7, 0.7),
+    ],
+)
+def test_initialized_stakes_enable_stickers(
+    monkeypatch,
+    stake,
+    area,
+    ep_key,
+    rental_key,
+    ep_roll,
+    rental_roll,
+):
+    gs = initialize_run("b_red", stake, "STAKEWIRING")
+    rng = gs["rng"]
+    original_random = rng.random
+    calls = []
+
+    def controlled_random(key, *args, **kwargs):
+        calls.append(key)
+        # Advance the actual stream even when controlling its returned roll.
+        value = original_random(key, *args, **kwargs)
+        return {ep_key: ep_roll, rental_key: rental_roll}.get(key, value)
+
+    monkeypatch.setattr(rng, "random", controlled_random)
+    card = create_card("Joker", rng, 1, area=area, forced_key="j_joker", game_state=gs)
+
+    assert card.eternal is (stake >= 4 and ep_roll > 0.7)
+    assert card.perishable is (stake >= 7 and 0.4 < ep_roll <= 0.7)
+    assert card.rental is (stake >= 8 and rental_roll > 0.7)
+    assert calls == [ep_key, rental_key, "edi1"]
+
+    # Compare the next draw on every touched stream to an unmodified reference.
+    reference = initialize_run("b_red", stake, "STAKEWIRING")["rng"]
+    for key in calls:
+        reference.random(key)
+    for key in tuple(calls):
+        assert original_random(key) == reference.random(key)
+
+
+@pytest.mark.parametrize(
+    "flag,attribute,ep_roll",
+    [
+        ("enable_eternals_in_shop", "eternal", 0.8),
+        ("enable_perishables_in_shop", "perishable", 0.5),
+        ("enable_rentals_in_shop", "rental", 0.8),
+    ],
+)
+@pytest.mark.parametrize(
+    "nested,flat,expected",
+    [
+        (None, True, True),
+        ({}, True, True),
+        (True, False, True),
+        (False, True, False),
+    ],
+)
+def test_sticker_flag_compatibility(monkeypatch, flag, attribute, ep_roll, nested, flat, expected):
+    gs = {flag: flat}
+    if nested is not None:
+        gs["modifiers"] = {} if nested == {} else {flag: nested}
+    rng = PseudoRandom("FLAGINPUT")
+    monkeypatch.setattr(rng, "random", lambda key: ep_roll if key == "etperpoll1" else 0.8)
+
+    card = create_card("Joker", rng, 1, forced_key="j_joker", game_state=gs)
+    assert getattr(card, attribute) is expected
+
+
+def test_gold_flags_do_not_add_stickers_outside_shop_or_pack(monkeypatch):
+    gs = initialize_run("b_red", 8, "NOSTICKERS")
+    calls = []
+
+    def roll(key):
+        calls.append(key)
+        return 0.8
+
+    monkeypatch.setattr(gs["rng"], "random", roll)
+    card = create_card("Joker", gs["rng"], 1, area="", forced_key="j_joker", game_state=gs)
+    assert not card.eternal
+    assert not card.perishable
+    assert not card.rental
+    assert calls == ["edi1"]


### PR DESCRIPTION
Fixes #13.

Normally initialized runs store stake sticker flags under `modifiers`, but `create_card` reads only top-level flags. As a result, normal Black-through-Gold runs do not activate the corresponding Eternal, Perishable, and Rental joker generation. With the issue's deterministic Gold fixture, the result changes from no stickers to the expected Eternal + Rental joker.

Read the nested flags first, preserving top-level values as a fallback for direct factory callers. An explicit nested `False` takes precedence. The change preserves sticker thresholds, shop/pack area restrictions, and RNG stream consumption.

Regression coverage starts from normal run initialization at all eight stakes and exercises both shop and pack creation, threshold boundaries, legacy inputs, nested precedence, and subsequent RNG values. The new tests produce **24 failures and 53 passes on the unmodified base**, then **77 passes with the fix**.

Validation on Python 3.12.13, arm64 macOS, using the existing lockfile:

- Factory, initialization, and new regression tests: **119 passed**.
- `pytest -q --tb=short -m 'not benchmark and not live'`: **1,650 passed, 14 skipped, 5 deselected**.
- `ruff check .` and `ruff format --check .`: passed.

This is a focused simulator wiring correction. Live-game parity was not run, and the change does not establish full higher-stake simulator qualification.
